### PR TITLE
add creadential feature to manage credentials at job location

### DIFF
--- a/pkg/provider.go
+++ b/pkg/provider.go
@@ -23,13 +23,13 @@ func Provider() *schema.Provider {
 			"username": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("JENKINS_USERNAME", ""),
 				Description: "username which should be used to loginto jenkins instance",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("JENKINS_PASSWORD", ""),
 				Description: "password which should be used to loginto jenkins instance",
 			},
 			"ca_cert": {

--- a/pkg/provider.go
+++ b/pkg/provider.go
@@ -43,6 +43,7 @@ func Provider() *schema.Provider {
 			"jenkins_job_xml":             job.XmlJob(),
 			"jenkins_plugin":              plugins.Plugin(),
 			"jenkins_username_credential": credentials.Username(),
+			"jenkins_secret_credential":   credentials.Secret(),
 			"jenkins_ssh_credential":      credentials.SSH(),
 			"jenkins_docker_credential":   credentials.Docker(),
 		},

--- a/pkg/resources/credentials/docker.go
+++ b/pkg/resources/credentials/docker.go
@@ -32,6 +32,11 @@ func Docker() *schema.Resource {
 				Optional: true,
 				Default:  "_",
 			},
+			"jobpath": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/pkg/resources/credentials/secret.go
+++ b/pkg/resources/credentials/secret.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/piotrjaromin/gojenkins"
+	"github.com/piotrjaromin/terraform-provider-jenkins/pkg/resources/credentials/util"
+)
+
+type secretProvider struct{}
+
+func Secret() *schema.Resource {
+
+	manager := util.CreateCredsManager(secretProvider{})
+
+	return &schema.Resource{
+		Create: manager.ResourceServerCreate,
+		Read:   manager.ResourceServerRead,
+		Update: manager.ResourceServerUpdate,
+		Delete: manager.ResourceServerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"secret": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"identifier": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "_",
+			},
+			"jobpath": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"scope": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "global",
+			},
+		},
+	}
+}
+
+func (secretProvider) Empty() interface{} {
+	return gojenkins.UsernameCredentials{}
+}
+
+func (secretProvider) FromResourceData(d *schema.ResourceData) (interface{}, error) {
+
+	return gojenkins.StringCredentials{
+		ID:          d.Get("identifier").(string),
+		Scope:       d.Get("scope").(string),
+		Secret:      d.Get("secret").(string),
+		Description: d.Get("description").(string),
+	}, nil
+}

--- a/pkg/resources/credentials/ssh.go
+++ b/pkg/resources/credentials/ssh.go
@@ -44,6 +44,11 @@ func SSH() *schema.Resource {
 				Optional: true,
 				Default:  "_",
 			},
+			"jobpath": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/pkg/resources/credentials/username.go
+++ b/pkg/resources/credentials/username.go
@@ -37,6 +37,11 @@ func Username() *schema.Resource {
 				Optional: true,
 				Default:  "_",
 			},
+			"jobpath": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/pkg/resources/credentials/util/manager.go
+++ b/pkg/resources/credentials/util/manager.go
@@ -26,13 +26,13 @@ func CreateCredsManager(provider CredsProvider) CredsManager {
 
 	create := func(d *schema.ResourceData, m interface{}) error {
 
-		cm, domain := getCMAndDomain(d, m)
+		cm, domain, jobPath := getCMAndDomain(d, m)
 		cred, err := provider.FromResourceData(d)
 		if err != nil {
 			return err
 		}
 
-		err = cm.Add(domain, cred)
+		err = cm.Add(domain, jobPath, cred)
 		if err != nil {
 			return err
 		}
@@ -44,10 +44,10 @@ func CreateCredsManager(provider CredsProvider) CredsManager {
 
 	read := func(d *schema.ResourceData, m interface{}) error {
 
-		cm, domain := getCMAndDomain(d, m)
+		cm, domain, jobPath := getCMAndDomain(d, m)
 
 		cred := provider.Empty()
-		err := cm.GetSingle(domain, d.Id(), &cred)
+		err := cm.GetSingle(domain, jobPath, d.Id(), &cred)
 		if err != nil {
 			return err
 		}
@@ -57,18 +57,18 @@ func CreateCredsManager(provider CredsProvider) CredsManager {
 	}
 
 	update := func(d *schema.ResourceData, m interface{}) error {
-		cm, domain := getCMAndDomain(d, m)
+		cm, domain, jobPath := getCMAndDomain(d, m)
 		cred, err := provider.FromResourceData(d)
 		if err != nil {
 			return err
 		}
 
-		return cm.Update(domain, id(cred), cred)
+		return cm.Update(domain, jobPath, id(cred), cred)
 	}
 
 	delete := func(d *schema.ResourceData, m interface{}) error {
-		cm, domain := getCMAndDomain(d, m)
-		return cm.Delete(domain, d.Get("id").(string))
+		cm, domain, jobPath := getCMAndDomain(d, m)
+		return cm.Delete(domain, jobPath, d.Id())
 	}
 
 	return CredsManager{

--- a/pkg/resources/credentials/util/util.go
+++ b/pkg/resources/credentials/util/util.go
@@ -5,11 +5,12 @@ import (
 	"github.com/piotrjaromin/gojenkins"
 )
 
-func getCMAndDomain(d *schema.ResourceData, m interface{}) (gojenkins.CredentialsManager, string) {
+func getCMAndDomain(d *schema.ResourceData, m interface{}) (gojenkins.CredentialsManager, string, string) {
 
 	client := m.(*gojenkins.Jenkins)
 	domain := d.Get("domain").(string)
+	jobPath := d.Get("jobpath").(string)
 
 	cm := gojenkins.CredentialsManager{J: client}
-	return cm, domain
+	return cm, domain, jobPath
 }


### PR DESCRIPTION
I make some changes to your plugin and your jenkins utils to avoid manage credentials located under job. You should use a new parameter "jobpath"  to indicate the location of the job.

Ex. 
resource "jenkins_username_credential" "cheduller01" {
    identifier = "terraform_create_credential_dos"
    username = "admin"
    password = "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
    jobpath = "Scheduller01"
    domain = "team01"
    description = "team01 - cheduller01"
}

I send you the pull request of the package that manage jenkins too.

- Enabled the posibility to export variables to get the user and password of jenkins
- Enabled the posibility to create secret text credentials